### PR TITLE
added a option to provide key which contains all queue

### DIFF
--- a/setup/docker/main.sh
+++ b/setup/docker/main.sh
@@ -7,11 +7,13 @@ metric_prefix="${EXPORTER_STAT_PREFIX:-bull_queue_}"
 queues="${EXPORTER_QUEUES:-}"
 EXPORTER_AUTODISCOVER="${EXPORTER_AUTODISCOVER:-}"
 EXPORTER_REDIS_CLUSTER="${EXPORTER_REDIS_CLUSTER:-}"
+EXPORTER_DISCOVER_QUEUES_KEY="${EXPORTER_DISCOVER_QUEUES_KEY:-}"
 
 flags=(
   --url "$url"
   --prefix "$prefix"
   --metric-prefix "$metric_prefix"
+  --discover-queues-key "${EXPORTER_DISCOVER_QUEUES_KEY}"
 )
 
 if [[ "$EXPORTER_AUTODISCOVER" != 0 && "$EXPORTER_AUTODISCOVER" != 'false' ]] ; then

--- a/src/options.ts
+++ b/src/options.ts
@@ -11,6 +11,7 @@ export interface Options {
   bindAddress: string;
   autoDiscover: boolean;
   useClusterMode: boolean;
+  discoverQueuesKey: string;
   _: string[];
 }
 
@@ -59,6 +60,11 @@ export function getOptionsFromArgs(...args: string[]): Options {
         alias: 'c',
         default: false,
         type: 'boolean',
+      },
+      discoverQueuesKey: {
+        alias: 'discover-queues-key',
+        default: 'queues',
+        type: 'string',
       },
     })
     .parse(args);

--- a/src/queueGauges.ts
+++ b/src/queueGauges.ts
@@ -8,7 +8,7 @@ export interface QueueGauges {
   delayed: Gauge<LabelsT>;
   failed: Gauge<LabelsT>;
   waiting: Gauge<LabelsT>;
-  completeSummary: Summary<LabelsT>;
+  completeSummary: Summary<LabelsT>
 }
 
 export function makeGuages(
@@ -53,7 +53,7 @@ export function makeGuages(
       name: `${statPrefix}waiting`,
       help: 'Number of waiting messages',
       labelNames: ['queue', 'prefix'],
-    }),
+    })
   };
 }
 


### PR DESCRIPTION
**Overview**
paragon has lot of queues which cause bull exporter to crash on boot on production. added a new option `EXPORTER_DISCOVER_QUEUES_KEY` a redis key which will contain all queue at a point of time.

